### PR TITLE
Scope Guard

### DIFF
--- a/pe_scope_guard/pe_scope_guard.hpp
+++ b/pe_scope_guard/pe_scope_guard.hpp
@@ -12,12 +12,7 @@ namespace peach
   template< typename... Tys > class ScopeGuard
   {
   public:
-    ScopeGuard( Tys&&... callables ) requires( ( std::same_as< std::invoke_result_t< Tys >, void > && ... ) )
-        : m_callables( std::make_tuple( std::forward< Tys >( callables )... ) )
-    {
-    }
-
-    ScopeGuard( Tys... callables ) requires( ( std::same_as< std::invoke_result_t< Tys >, void > && ... ) )
+    constexpr ScopeGuard( Tys... callables ) requires( ( std::same_as< std::invoke_result_t< Tys >, void > && ... ) )
         : m_callables( std::make_tuple( callables... ) )
     {
     }

--- a/pe_scope_guard/pe_scope_guard.hpp
+++ b/pe_scope_guard/pe_scope_guard.hpp
@@ -1,0 +1,36 @@
+#ifndef PE_SCOPE_GUARD_HPP
+#define PE_SCOPE_GUARD_HPP
+
+#include <concepts>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace peach
+{
+
+  template< typename... Tys > class ScopeGuard
+  {
+  public:
+    ScopeGuard( Tys&&... callables ) requires( ( std::same_as< std::invoke_result_t< Tys >, void > && ... ) )
+        : m_callables( std::make_tuple( std::forward< Tys >( callables )... ) )
+    {
+    }
+
+    ScopeGuard( Tys... callables ) requires( ( std::same_as< std::invoke_result_t< Tys >, void > && ... ) )
+        : m_callables( std::make_tuple( callables... ) )
+    {
+    }
+
+    ~ScopeGuard( ) noexcept
+    {
+      std::apply( []( auto&&... args ) { ( ( args( ) ), ... ); }, m_callables );
+    }
+
+  private:
+    std::tuple< Tys... > m_callables;
+  };
+
+} // namespace peach
+
+#endif // PE_SCOPE_GUARD_HPP


### PR DESCRIPTION
# Overview
This pull request and code is written by both me and @Nerlant. Credits to him for helping and partly writing the code


## Changes:
- *adds scope guard base*

## Usage
```cpp
#include <concepts>
#include <tuple>
#include <type_traits>
#include <utility>

#include <Windows.h>
#include <tlhelp32.h>

#include <pe_scope_guard/pe_scope_guard.hpp>

int main()
{
	const HANDLE a = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
	const HANDLE b = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
	{

		// lambda
		auto c = [a]() { CloseHandle(a); };

		// A combination of c and rvalue lambda's is completely fine
		peach::ScopeGuard test(
			[a]() { CloseHandle(a); },
			[b]() { CloseHandle(b); },
			c
		);

	}

	// Handles closed here
}
```

## Any changes on files besides the ones directly connected to your feature/change (emtpy if none):
- *none*

## Additional Notes:
With clang 11 in release the dissambly will look like:
```cpp
  HANDLE v0; // rsi
  HANDLE v1; // rsi

  v0 = CreateToolhelp32Snapshot(2u, 0);
  v1 = CreateToolhelp32Snapshot(2u, 0);
  v0 = CreateToolhelp32Snapshot(2u, 0);
  CloseHandle(v0);
  CloseHandle(v1);
  JUMPOUT(func);
```
Quite optimal to say the least.

- *One can pass lvalue lambda's, rvalue lambda's and plain c-style functions*
- *Amount of arguments and functors is unlimited*
- *The constructor is `constexpr` if the passed values passed through the capture list are compile time*
- *If the dtor throws `std::terminate()` is called*
- *The functor passed must have `void` as return type because the return value is neglected either way*

</br>

# Tests:
- [x] Test feature thorougly  
- [x] Compiles w/ clang 11  
- [x] Formatted according to the .clang-format  

# Extra
- [ ] Add explanation/documentation on wiki/readme page
